### PR TITLE
Fix review findings across skim, project, and diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ jskim <file.java> --annotation <@Ann>     # filter methods by annotation
 jskim A.java B.java C.java                # multiple files
 ```
 
+Java simple source files without an explicit type wrapper are summarized as `implicit class <FileStem>`, and their top-level methods are treated like normal class methods.
+
 ### Project map
 
 Generates a compact map of all Java files in a directory: packages, classes, annotations, field/method counts, Lombok usage, enum constants.
@@ -62,6 +64,7 @@ git diff main | jskim --diff -         # read diff from stdin
 ```
 
 Output marks methods as `[NEW]`, `[MODIFIED]`, or `[DELETED]`. Getters/setters/boilerplate changes are suppressed.
+Deleted methods are shown with their previous signature when a base ref is available, so overload removals stay distinguishable.
 
 ### Extract methods
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -35,6 +35,8 @@ jskim <file.java> --annotation <@Ann>    # filter methods by annotation
 jskim A.java B.java C.java               # multiple files
 ```
 
+Java simple source files without an explicit type wrapper are summarized as `implicit class <FileStem>`, and their top-level methods are treated like normal class methods.
+
 **Filters** (useful for large files with many methods):
 - `--grep billing` — show only methods whose signature contains "billing" (case-insensitive)
 - `--annotation @Transactional` — show only methods with that annotation
@@ -80,6 +82,7 @@ git diff main | jskim --diff -         # read diff from stdin
 - `[NEW]` — file or method that was added
 - `[MODIFIED]` — method whose body was changed
 - `[DELETED]` — file or method that was removed
+- Deleted methods are shown with their previous signature when the base ref is available, so overload removals stay distinguishable
 - `→` calls shown for new/modified methods (same format as file summary)
 - Getters, setters, and boilerplate changes are suppressed (not interesting)
 - Unchanged methods are counted but not listed
@@ -134,6 +137,18 @@ jskim <file.java> <method1> <method2> <method3>   # extract multiple
 //   L100: class BillingHelper [2F, 3M]     <- 2F = 2 fields, 3M = 3 methods
 //
 // total: 120 lines
+```
+
+For Java simple source files:
+```
+// SomeScript.java
+// (default) | 0 imports
+// implicit class SomeScript
+//
+// methods:
+//         L1-L3 (  3 lines): void main()
+//
+// total: 3 lines
 ```
 
 For enums:
@@ -255,6 +270,7 @@ With `--deps`:
 - `fields:` lists class fields for context
 - `called methods in same class` shows other methods referenced in the extracted method bodies
 - `// not found: methodX` appears if a requested method name wasn't found
+- Simple source files use the same format with an `implicit class <FileStem>` header
 
 ## Workflow
 

--- a/src/jskim/diff.py
+++ b/src/jskim/diff.py
@@ -121,10 +121,10 @@ def _resolve_base_ref(ref, cwd=None):
     return ref
 
 
-def _get_old_method_names(base_ref, path, cwd=None):
-    """Get method names from the old version of a file.
+def _get_old_methods(base_ref, path, cwd=None):
+    """Get method identities and signatures from the old version of a file.
 
-    Returns a set of method names, or None if the old file cannot be retrieved.
+    Returns a dict {identity: signature}, or None if the old file cannot be retrieved.
     """
     result = subprocess.run(
         ["git", "show", f"{base_ref}:{path}"],
@@ -133,13 +133,11 @@ def _get_old_method_names(base_ref, path, cwd=None):
     if result.returncode != 0:
         return None
     try:
-        parsed = parse_java(result.stdout)
-        names = set()
+        parsed = parse_java(result.stdout, source_name=path)
+        methods = {}
         for m in parsed["methods"]:
-            name_match = re.search(r"(\w+)\s*\(", m["sig"])
-            if name_match:
-                names.add(name_match.group(1))
-        return names
+            methods[m["identity"]] = m["sig"]
+        return methods
     except Exception:
         return None
 
@@ -271,11 +269,11 @@ def format_diff_output(changed_files, git_root, base_ref, scope=None):
 
         changed_lines = f["changed_lines"]
 
-        # Get old method names for NEW/DELETED detection
-        old_method_names = None
+        # Get old method identities for NEW/DELETED detection
+        old_methods = None
         if base_ref:
             old_path = f.get("old_path", f["path"])
-            old_method_names = _get_old_method_names(base_ref, old_path, cwd=git_root)
+            old_methods = _get_old_methods(base_ref, old_path, cwd=git_root)
 
         out.append(f"// {f['path']}")
         if parsed["class_annotations"]:
@@ -286,16 +284,15 @@ def format_diff_output(changed_files, git_root, base_ref, scope=None):
         modified_methods = []
         unchanged_count = 0
 
-        current_method_names = set()
+        current_method_ids = set()
         for m in parsed["methods"]:
-            name_match = re.search(r"(\w+)\s*\(", m["sig"])
-            name = name_match.group(1) if name_match else m["sig"]
-            current_method_names.add(name)
+            method_id = m.get("identity", m["sig"])
+            current_method_ids.add(method_id)
 
             kind = classify_method(m["sig"])
             is_trivial = kind in ("getter", "setter", "boilerplate")
 
-            if old_method_names is not None and name not in old_method_names:
+            if old_methods is not None and method_id not in old_methods:
                 # Method exists in current but not in old -> NEW
                 if not is_trivial:
                     new_methods.append(m)
@@ -311,9 +308,9 @@ def format_diff_output(changed_files, git_root, base_ref, scope=None):
                 unchanged_count += 1
 
         # Detect deleted methods
-        deleted_method_names = []
-        if old_method_names is not None:
-            deleted_method_names = sorted(old_method_names - current_method_names)
+        deleted_method_ids = []
+        if old_methods is not None:
+            deleted_method_ids = sorted(set(old_methods) - current_method_ids)
 
         for m in new_methods:
             lines = m["end"] - m["start"] + 1
@@ -345,10 +342,10 @@ def format_diff_output(changed_files, git_root, base_ref, scope=None):
                 else:
                     out.append(f"//     → {', '.join(calls[:10])}, ... +{len(calls) - 10} more")
 
-        for name in deleted_method_names:
-            out.append(f"//   [DELETED]  {name}()")
+        for method_id in deleted_method_ids:
+            out.append(f"//   [DELETED]  {old_methods[method_id]}")
 
-        if not new_methods and not modified_methods and not deleted_method_names:
+        if not new_methods and not modified_methods and not deleted_method_ids:
             out.append("//   (non-method changes only)")
 
         if unchanged_count:

--- a/src/jskim/method.py
+++ b/src/jskim/method.py
@@ -20,24 +20,22 @@ from .util import (
     get_body_members, get_annotations, get_modifiers_node,
     build_method_signature, build_class_declaration_text,
     extract_field_info, extract_record_components, get_declaration_name,
+    build_implicit_class_declaration,
     METHOD_NODES,
 )
 
 
 
-def _parse_type_methods(decl):
-    """Parse methods and fields from a single type declaration node."""
-    class_name = get_declaration_name(decl)
-    class_declaration = build_class_declaration_text(decl)
+def _parse_members(class_name, class_declaration, members, record_components=None):
+    """Parse methods and fields from a member list."""
     fields = []
     methods = []
 
     # Record components (shown as fields)
-    for ftype, fname in extract_record_components(decl):
+    for ftype, fname in record_components or []:
         fields.append(f"{ftype} {fname}" if fname else ftype)
 
-    body = get_class_body(decl)
-    for member in get_body_members(body):
+    for member in members:
         if member.type == "field_declaration":
             field_entries = extract_field_info(member)
             for ftype, fname in field_entries:
@@ -67,23 +65,47 @@ def _parse_type_methods(decl):
     return class_name, class_declaration, fields, methods
 
 
-def parse_methods(content):
+def _parse_type_methods(decl):
+    """Parse methods and fields from a single type declaration node."""
+    class_name = get_declaration_name(decl)
+    class_declaration = build_class_declaration_text(decl)
+    return _parse_members(
+        class_name,
+        class_declaration,
+        get_body_members(get_class_body(decl)),
+        extract_record_components(decl),
+    )
+
+
+def _parse_implicit_methods(program_members, source_name=None):
+    """Parse the implicit class members of a Java simple source file."""
+    class_name = Path(source_name).stem if source_name else "implicit class"
+    class_declaration = build_implicit_class_declaration(source_name)
+    return _parse_members(class_name, class_declaration, program_members)
+
+
+def parse_methods(content, source_name=None):
     """Parse all methods from a Java file using tree-sitter."""
     structure = parse_file_structure(content.encode("utf-8"))
     lines = content.split("\n")
 
-    class_name = None
-    class_declaration = None
-    fields = []
-    methods = []
+    if structure["program_members"]:
+        class_name, class_declaration, fields, methods = _parse_implicit_methods(
+            structure["program_members"], source_name
+        )
+    else:
+        class_name = None
+        class_declaration = None
+        fields = []
+        methods = []
 
-    for node in structure["type_nodes"]:
-        cn, cd, fs, ms = _parse_type_methods(node)
-        if class_name is None:
-            class_name = cn
-            class_declaration = cd
-            fields = fs
-        methods.extend(ms)
+        for node in structure["type_nodes"]:
+            cn, cd, fs, ms = _parse_type_methods(node)
+            if class_name is None:
+                class_name = cn
+                class_declaration = cd
+                fields = fs
+            methods.extend(ms)
 
     return {
         "package": structure["package"],
@@ -202,7 +224,7 @@ def main():
         sys.exit(1)
 
     content = filepath.read_text(encoding="utf-8", errors="replace")
-    parsed = parse_methods(content)
+    parsed = parse_methods(content, source_name=filepath)
 
     if sys.argv[2] == "--list":
         print(list_methods(parsed))

--- a/src/jskim/project.py
+++ b/src/jskim/project.py
@@ -38,6 +38,110 @@ def _join_paths(base, method_path):
     return base.rstrip("/") + "/" + method_path.lstrip("/")
 
 
+def _scan_members(
+    members,
+    class_type,
+    class_name,
+    annotations,
+    is_controller=False,
+    is_spring_bean=False,
+    has_constructor_injection=False,
+    base_paths=None,
+):
+    """Scan fields, methods, and nested types from a member list."""
+    if not base_paths:
+        base_paths = [""]
+
+    field_count = 0
+    method_count = 0
+    inner_types = []
+    endpoints = []
+    bean_deps = []
+    bean_produces = []
+    fields_detail = []
+    static_initializers = []
+
+    for member in members:
+        if member.type == "field_declaration":
+            field_entries = extract_field_info(member)
+            field_count += len(field_entries)
+
+            for ftype, fname in field_entries:
+                fields_detail.append({"type": ftype, "name": fname})
+
+            if is_spring_bean:
+                field_mods = get_modifiers_node(member)
+                field_anns = get_annotations(field_mods) if field_mods else []
+                field_final = is_field_final(member)
+                field_static = is_field_static(member)
+                is_injected = (
+                    "@Autowired" in field_anns or "@Inject" in field_anns
+                    or (has_constructor_injection and field_final and not field_static)
+                )
+                if is_injected:
+                    for ftype, fname in field_entries:
+                        if ftype:
+                            dep_type = ftype.split("<")[0].strip()
+                            bean_deps.append(dep_type)
+
+        elif member.type in METHOD_NODES:
+            method_count += 1
+
+            method_mods = get_modifiers_node(member)
+
+            if is_controller and method_mods:
+                for child in method_mods.children:
+                    if child.type in ("marker_annotation", "annotation"):
+                        ann_name = get_annotation_name_from_node(child)
+                        if ann_name in HTTP_MAPPING_ANNOTATIONS:
+                            http_method = HTTP_MAPPING_ANNOTATIONS[ann_name]
+                            if http_method is None:
+                                http_method = extract_request_method(child) or "REQUEST"
+                            method_paths = extract_mapping_paths(child)
+                            if not method_paths:
+                                method_paths = [""]
+                            name_node = member.child_by_field_name("name")
+                            method_name = name_node.text.decode() if name_node else "?"
+                            start_line = member.start_point[0] + 1
+                            for bp in base_paths:
+                                for mp in method_paths:
+                                    endpoints.append({
+                                        "method": http_method,
+                                        "path": _join_paths(bp, mp),
+                                        "handler": f"{class_name}.{method_name}()",
+                                        "line": start_line,
+                                    })
+
+            if method_mods:
+                method_anns = get_annotations(method_mods)
+                if "@Bean" in method_anns:
+                    type_node = member.child_by_field_name("type")
+                    if type_node:
+                        bean_type = type_node.text.decode().split("<")[0].strip()
+                        bean_produces.append(bean_type)
+
+        elif member.type == "static_initializer":
+            start = member.start_point[0] + 1
+            end = member.end_point[0] + 1
+            static_initializers.append({"start": start, "end": end})
+
+        elif member.type in INNER_TYPE_NODES:
+            kw = get_type_keyword(member)
+            nm = get_declaration_name(member)
+            inner_types.append(f"{kw} {nm}")
+
+    return {
+        "field_count": field_count,
+        "method_count": method_count,
+        "inner_types": inner_types,
+        "endpoints": endpoints,
+        "bean_deps": bean_deps,
+        "bean_produces": bean_produces,
+        "fields_detail": fields_detail,
+        "static_initializers": static_initializers,
+    }
+
+
 def _scan_type_declaration(decl):
     """Extract structural info from a single type declaration node."""
     class_type = get_type_keyword(decl)
@@ -74,100 +178,25 @@ def _scan_type_declaration(decl):
     if not base_paths:
         base_paths = [""]
 
-    field_count = 0
-    method_count = 0
-    inner_types = []
-    endpoints = []
-    bean_deps = []
-    bean_produces = []
-    fields_detail = []
     enum_constants_list = []
-    static_initializers = []
-
-    # Record components count as fields
-    record_components = extract_record_components(decl)
-    field_count += len(record_components)
-    for ftype, fname in record_components:
-        fields_detail.append({"type": ftype, "name": fname})
 
     body = get_class_body(decl)
+    scanned_members = _scan_members(
+        get_body_members(body),
+        class_type,
+        class_name,
+        annotations,
+        is_controller=is_controller,
+        is_spring_bean=is_spring_bean,
+        has_constructor_injection=has_constructor_injection,
+        base_paths=base_paths,
+    )
 
-    # Enum constants
     if class_type == "enum" and body:
         enum_constants_list = get_enum_constants(body)
 
-    for member in get_body_members(body):
-        if member.type == "field_declaration":
-            field_entries = extract_field_info(member)
-            field_count += len(field_entries)
-
-            # Collect field details for config-properties display
-            for ftype, fname in field_entries:
-                fields_detail.append({"type": ftype, "name": fname})
-
-            # Bean dependency detection
-            if is_spring_bean:
-                field_mods = get_modifiers_node(member)
-                field_anns = get_annotations(field_mods) if field_mods else []
-                field_final = is_field_final(member)
-                field_static = is_field_static(member)
-                is_injected = (
-                    "@Autowired" in field_anns or "@Inject" in field_anns
-                    or (has_constructor_injection and field_final and not field_static)
-                )
-                if is_injected:
-                    for ftype, fname in field_entries:
-                        if ftype:
-                            dep_type = ftype.split("<")[0].strip()
-                            bean_deps.append(dep_type)
-
-        elif member.type in METHOD_NODES:
-            method_count += 1
-
-            method_mods = get_modifiers_node(member)
-
-            # Endpoint detection for controllers
-            if is_controller and method_mods:
-                for child in method_mods.children:
-                    if child.type in ("marker_annotation", "annotation"):
-                        ann_name = get_annotation_name_from_node(child)
-                        if ann_name in HTTP_MAPPING_ANNOTATIONS:
-                            http_method = HTTP_MAPPING_ANNOTATIONS[ann_name]
-                            if http_method is None:
-                                http_method = extract_request_method(child) or "REQUEST"
-                            method_paths = extract_mapping_paths(child)
-                            if not method_paths:
-                                method_paths = [""]
-                            name_node = member.child_by_field_name("name")
-                            method_name = name_node.text.decode() if name_node else "?"
-                            start_line = member.start_point[0] + 1
-                            for bp in base_paths:
-                                for mp in method_paths:
-                                    endpoints.append({
-                                        "method": http_method,
-                                        "path": _join_paths(bp, mp),
-                                        "handler": f"{class_name}.{method_name}()",
-                                        "line": start_line,
-                                    })
-
-            # @Bean producer detection
-            if method_mods:
-                method_anns = get_annotations(method_mods)
-                if "@Bean" in method_anns:
-                    type_node = member.child_by_field_name("type")
-                    if type_node:
-                        bean_type = type_node.text.decode().split("<")[0].strip()
-                        bean_produces.append(bean_type)
-
-        elif member.type == "static_initializer":
-            start = member.start_point[0] + 1
-            end = member.end_point[0] + 1
-            static_initializers.append({"start": start, "end": end})
-
-        elif member.type in INNER_TYPE_NODES:
-            kw = get_type_keyword(member)
-            nm = get_declaration_name(member)
-            inner_types.append(f"{kw} {nm}")
+    record_components = extract_record_components(decl)
+    record_fields = [{"type": ftype, "name": fname} for ftype, fname in record_components]
 
     return {
         "class_type": class_type,
@@ -176,16 +205,38 @@ def _scan_type_declaration(decl):
         "lombok": lombok_anns,
         "extends": extends,
         "implements": ifaces,
-        "field_count": field_count,
-        "method_count": method_count,
-        "inner_types": inner_types,
+        "field_count": len(record_fields) + scanned_members["field_count"],
+        "method_count": scanned_members["method_count"],
+        "inner_types": scanned_members["inner_types"],
         "enum_constants": enum_constants_list,
-        "endpoints": endpoints,
-        "bean_deps": bean_deps,
-        "bean_produces": bean_produces,
+        "endpoints": scanned_members["endpoints"],
+        "bean_deps": scanned_members["bean_deps"],
+        "bean_produces": scanned_members["bean_produces"],
         "config_prefix": config_prefix,
-        "fields_detail": fields_detail,
-        "static_initializers": static_initializers,
+        "fields_detail": record_fields + scanned_members["fields_detail"],
+        "static_initializers": scanned_members["static_initializers"],
+    }
+
+
+def _scan_implicit_source_file(filepath, program_members):
+    """Scan the implicit class produced by a Java simple source file."""
+    class_name = filepath.stem
+    scanned_members = _scan_members(
+        program_members,
+        "implicit class",
+        class_name,
+        [],
+    )
+    return {
+        "class_type": "implicit class",
+        "class_name": class_name,
+        "annotations": [],
+        "lombok": [],
+        "extends": None,
+        "implements": [],
+        "enum_constants": [],
+        "config_prefix": None,
+        **scanned_members,
     }
 
 
@@ -199,8 +250,8 @@ def scan_java_file(filepath):
     total_lines = len(content.split("\n"))
 
     results = []
-    for node in structure["type_nodes"]:
-        info = _scan_type_declaration(node)
+    if structure["program_members"]:
+        info = _scan_implicit_source_file(filepath, structure["program_members"])
         results.append({
             "filepath": filepath,
             "package": structure["package"],
@@ -208,6 +259,16 @@ def scan_java_file(filepath):
             "total_lines": total_lines,
             **info,
         })
+    else:
+        for node in structure["type_nodes"]:
+            info = _scan_type_declaration(node)
+            results.append({
+                "filepath": filepath,
+                "package": structure["package"],
+                "imports": structure["imports"],
+                "total_lines": total_lines,
+                **info,
+            })
 
     return results
 
@@ -263,6 +324,25 @@ def find_dependencies(file_info_list):
     return deps
 
 
+def _count_unique_files(file_infos):
+    """Count files and lines once per filepath, not once per top-level type."""
+    unique_files = {}
+    fallback_count = 0
+    fallback_lines = 0
+
+    for info in file_infos:
+        filepath = info.get("filepath")
+        if filepath is None:
+            fallback_count += 1
+            fallback_lines += info.get("total_lines", 0)
+            continue
+
+        if filepath not in unique_files:
+            unique_files[filepath] = info.get("total_lines", 0)
+
+    return len(unique_files) + fallback_count, sum(unique_files.values()) + fallback_lines
+
+
 def format_output(file_infos, show_deps=False, show_endpoints=False, show_beans=False):
     """Format the project map."""
     out = []
@@ -272,16 +352,15 @@ def format_output(file_infos, show_deps=False, show_endpoints=False, show_beans=
         pkg = info["package"] or "(default)"
         packages[pkg].append(info)
 
-    total_files = len(file_infos)
-    total_lines = sum(info["total_lines"] for info in file_infos)
+    total_files, total_lines = _count_unique_files(file_infos)
 
     out.append(f"// Project Map: {total_files} files, {total_lines} lines")
     out.append("//")
 
     for pkg in sorted(packages.keys()):
         infos = sorted(packages[pkg], key=lambda x: x["class_name"] or "")
-        pkg_lines = sum(i["total_lines"] for i in infos)
-        out.append(f"// {pkg} ({len(infos)} files, {pkg_lines} lines)")
+        pkg_files, pkg_lines = _count_unique_files(infos)
+        out.append(f"// {pkg} ({pkg_files} files, {pkg_lines} lines)")
 
         for info in infos:
             name = info["class_name"] or "(unknown)"
@@ -309,7 +388,8 @@ def format_output(file_infos, show_deps=False, show_endpoints=False, show_beans=
             if info["extends"]:
                 desc += f" extends {info['extends']}"
             if info["implements"]:
-                desc += f" implements {', '.join(info['implements'])}"
+                keyword = "extends" if ctype == "interface" else "implements"
+                desc += f" {keyword} {', '.join(info['implements'])}"
 
             extras = []
             if info["field_count"]:

--- a/src/jskim/skim.py
+++ b/src/jskim/skim.py
@@ -14,7 +14,7 @@ from .util import (
     build_method_signature, build_class_declaration_text,
     extract_field_info, extract_record_components, get_type_keyword,
     get_declaration_name, get_interfaces, get_enum_constants,
-    extract_method_calls,
+    extract_method_calls, build_implicit_class_declaration, build_method_identity,
     INNER_TYPE_NODES, METHOD_NODES, MODIFIER_KEYWORDS,
 )
 
@@ -108,36 +108,13 @@ def classify_method(sig):
 
 
 
-def _parse_type_declaration(decl):
-    """Parse a single type declaration node and return its structural info."""
-    mods = get_modifiers_node(decl)
-    rich_anns = get_annotations_rich(mods)
-    class_annotations = [a["full"] for a in rich_anns]
-    class_declaration = build_class_declaration_text(decl)
-    class_line = decl.start_point[0] + 1
-
-    lombok_notes = []
-    for a in rich_anns:
-        if a["name"] in LOMBOK_ANNOTATIONS:
-            lombok_notes.append(f"{a['name']}: {LOMBOK_ANNOTATIONS[a['name']]}")
-
+def _parse_members(members):
+    """Parse fields, methods, and nested declarations from a member list."""
     fields = []
     methods = []
     inner_types = []
-    enum_constants_list = []
     static_initializers = []
-
-    # Record components (shown as fields)
-    for ftype, fname in extract_record_components(decl):
-        fields.append({"type": ftype, "name": fname, "annotations": ""})
-
-    body = get_class_body(decl)
-
-    # Enum constants
-    if decl.type == "enum_declaration" and body:
-        enum_constants_list = get_enum_constants(body)
-
-    for member in get_body_members(body):
+    for member in members:
         if member.type == "field_declaration":
             field_entries = extract_field_info(member)
             anns = get_annotations(get_modifiers_node(member))
@@ -161,6 +138,7 @@ def _parse_type_declaration(decl):
                 "start": start,
                 "end": end,
                 "sig": sig,
+                "identity": build_method_identity(member),
                 "annotations": anns,
                 "calls": calls,
             })
@@ -181,44 +159,97 @@ def _parse_type_declaration(decl):
             })
 
     return {
-        "class_annotations": class_annotations,
-        "class_declaration": class_declaration,
-        "class_line": class_line,
         "fields": fields,
         "methods": methods,
         "inner_types": inner_types,
-        "lombok_notes": lombok_notes,
-        "enum_constants": enum_constants_list,
         "static_initializers": static_initializers,
     }
 
 
-def parse_java(content):
+def _parse_type_declaration(decl):
+    """Parse a single type declaration node and return its structural info."""
+    mods = get_modifiers_node(decl)
+    rich_anns = get_annotations_rich(mods)
+    class_annotations = [a["full"] for a in rich_anns]
+    class_declaration = build_class_declaration_text(decl)
+    class_line = decl.start_point[0] + 1
+
+    lombok_notes = []
+    for a in rich_anns:
+        if a["name"] in LOMBOK_ANNOTATIONS:
+            lombok_notes.append(f"{a['name']}: {LOMBOK_ANNOTATIONS[a['name']]}")
+
+    body = get_class_body(decl)
+    parsed_members = _parse_members(get_body_members(body))
+
+    # Record components (shown as fields)
+    record_fields = []
+    for ftype, fname in extract_record_components(decl):
+        record_fields.append({"type": ftype, "name": fname, "annotations": ""})
+
+    enum_constants_list = []
+    if decl.type == "enum_declaration" and body:
+        enum_constants_list = get_enum_constants(body)
+
+    return {
+        "class_annotations": class_annotations,
+        "class_declaration": class_declaration,
+        "class_line": class_line,
+        "fields": record_fields + parsed_members["fields"],
+        "methods": parsed_members["methods"],
+        "inner_types": parsed_members["inner_types"],
+        "lombok_notes": lombok_notes,
+        "enum_constants": enum_constants_list,
+        "static_initializers": parsed_members["static_initializers"],
+    }
+
+
+def _parse_implicit_declaration(program_members, source_name=None):
+    """Parse the synthetic implicit class for a Java simple source file."""
+    parsed_members = _parse_members(program_members)
+    return {
+        "class_annotations": [],
+        "class_declaration": build_implicit_class_declaration(source_name),
+        "class_line": 1,
+        "fields": parsed_members["fields"],
+        "methods": parsed_members["methods"],
+        "inner_types": parsed_members["inner_types"],
+        "lombok_notes": [],
+        "enum_constants": [],
+        "static_initializers": parsed_members["static_initializers"],
+    }
+
+
+def parse_java(content, source_name=None):
     """Parse a Java file using tree-sitter and extract structural information."""
     structure = parse_file_structure(content.encode("utf-8"))
     lines = content.split("\n")
 
-    type_declarations = [_parse_type_declaration(node) for node in structure["type_nodes"]]
-
-    if not type_declarations:
-        # Implicitly declared class (Java 23+): no type declaration wrapper
-        primary = {
-            "class_annotations": [],
-            "class_declaration": None,
-            "class_line": 1,
-            "fields": [],
-            "methods": [],
-            "inner_types": [],
-            "lombok_notes": [],
-            "enum_constants": [],
-            "static_initializers": [],
-        }
+    if structure["program_members"]:
+        primary = _parse_implicit_declaration(structure["program_members"], source_name)
+        extra_types = []
     else:
-        # Primary class is the first declaration
-        primary = type_declarations[0]
+        type_declarations = [_parse_type_declaration(node) for node in structure["type_nodes"]]
 
-    # Additional top-level classes (package-private helpers, sealed subtypes, etc.)
-    extra_types = type_declarations[1:]
+        if not type_declarations:
+            primary = {
+                "class_annotations": [],
+                "class_declaration": None,
+                "class_line": 1,
+                "fields": [],
+                "methods": [],
+                "inner_types": [],
+                "lombok_notes": [],
+                "enum_constants": [],
+                "static_initializers": [],
+            }
+            extra_types = []
+        else:
+            # Primary class is the first declaration
+            primary = type_declarations[0]
+
+            # Additional top-level classes (package-private helpers, sealed subtypes, etc.)
+            extra_types = type_declarations[1:]
 
     return {
         "package": structure["package"],
@@ -419,7 +450,7 @@ def main():
             continue
 
         content = filepath.read_text(encoding="utf-8", errors="replace")
-        parsed = parse_java(content)
+        parsed = parse_java(content, source_name=filepath)
         print(format_output(parsed, filepath, grep=grep, annotation=annotation))
         if len(files) > 1:
             print()

--- a/src/jskim/util.py
+++ b/src/jskim/util.py
@@ -1,5 +1,7 @@
 """Shared tree-sitter utilities for the jskim toolkit."""
 
+from pathlib import Path
+
 import tree_sitter_java as tsjava
 import tree_sitter
 
@@ -13,10 +15,16 @@ INNER_TYPE_NODES = {
     "annotation_type_declaration",
 }
 
+PROGRAM_STRUCTURE_NODES = {"package_declaration", "import_declaration"}
+
 METHOD_NODES = {
     "method_declaration", "constructor_declaration",
     "compact_constructor_declaration", "annotation_type_element_declaration",
 }
+
+IMPLICIT_CLASS_MEMBER_NODES = METHOD_NODES | {"field_declaration", "static_initializer"}
+
+PARAMETER_NODES = {"formal_parameter", "spread_parameter", "receiver_parameter"}
 
 LOMBOK_SET = {
     "@Data", "@Value", "@Getter", "@Setter", "@Builder", "@SuperBuilder",
@@ -81,6 +89,40 @@ def build_method_signature(node):
     return sig
 
 
+def build_method_identity(node):
+    """Build a stable method identity using just the name and parameter types."""
+    name_node = node.child_by_field_name("name")
+    if not name_node:
+        for child in node.children:
+            if child.type == "identifier":
+                name_node = child
+                break
+    name = name_node.text.decode() if name_node else "unknown"
+
+    params_node = node.child_by_field_name("parameters")
+    if params_node is None:
+        for child in node.children:
+            if child.type == "formal_parameters":
+                params_node = child
+                break
+
+    param_types = []
+    if params_node is not None:
+        for param in params_node.named_children:
+            if param.type not in PARAMETER_NODES:
+                continue
+            type_node = param.child_by_field_name("type")
+            if type_node is not None:
+                type_text = type_node.text.decode()
+                if param.type == "spread_parameter":
+                    type_text += "..."
+                param_types.append(type_text)
+            else:
+                param_types.append(param.text.decode())
+
+    return f"{name}({', '.join(param_types)})"
+
+
 def extract_import_path(import_node):
     """Extract the import path string from an import_declaration node.
 
@@ -107,13 +149,17 @@ def parse_file_structure(source_bytes):
       - "package": package name string or None
       - "imports": list of import path strings
       - "type_nodes": list of top-level type declaration AST nodes
+      - "program_members": implicit-class members when the file has loose
+        top-level declarations (methods, fields, nested types, etc.)
     """
     root = parse_java_bytes(source_bytes)
     package = None
     imports = []
     type_nodes = []
+    program_members = []
+    non_structure_nodes = []
 
-    for child in root.children:
+    for child in root.named_children:
         if child.type == "package_declaration":
             for sub in child.children:
                 if sub.type in ("scoped_identifier", "identifier"):
@@ -123,10 +169,23 @@ def parse_file_structure(source_bytes):
             path = extract_import_path(child)
             if path:
                 imports.append(path)
-        elif child.type in INNER_TYPE_NODES:
-            type_nodes.append(child)
+        elif child.type not in PROGRAM_STRUCTURE_NODES:
+            non_structure_nodes.append(child)
 
-    return {"package": package, "imports": imports, "type_nodes": type_nodes}
+    if any(child.type in IMPLICIT_CLASS_MEMBER_NODES for child in non_structure_nodes):
+        program_members = [
+            child for child in non_structure_nodes
+            if child.type in IMPLICIT_CLASS_MEMBER_NODES or child.type in INNER_TYPE_NODES
+        ]
+    else:
+        type_nodes = [child for child in non_structure_nodes if child.type in INNER_TYPE_NODES]
+
+    return {
+        "package": package,
+        "imports": imports,
+        "type_nodes": type_nodes,
+        "program_members": program_members,
+    }
 
 
 def find_first_type_declaration(root):
@@ -187,6 +246,15 @@ def get_declaration_name(decl_node):
     return None
 
 
+def build_implicit_class_declaration(source_name=None):
+    """Build a display label for a Java simple source file's implicit class."""
+    if source_name:
+        stem = Path(str(source_name)).stem
+        if stem:
+            return f"implicit class {stem}"
+    return "implicit class"
+
+
 def get_superclass(decl_node):
     """Extract the extends clause text (just the type, not the 'extends' keyword)."""
     for child in decl_node.children:
@@ -198,9 +266,13 @@ def get_superclass(decl_node):
 
 
 def get_interfaces(decl_node):
-    """Extract implemented interface names as a list of strings."""
+    """Extract related interface names as a list of strings.
+
+    For classes/records, this returns implemented interfaces.
+    For interfaces, this returns extended interfaces.
+    """
     for child in decl_node.children:
-        if child.type == "super_interfaces":
+        if child.type in ("super_interfaces", "extends_interfaces"):
             for sub in child.children:
                 if sub.type == "type_list":
                     return [t.text.decode() for t in sub.named_children]
@@ -247,7 +319,7 @@ def build_class_declaration_text(decl_node):
 
     ifaces = get_interfaces(decl_node)
     if ifaces:
-        parts.append("implements")
+        parts.append("extends" if decl_node.type == "interface_declaration" else "implements")
         parts.append(", ".join(" ".join(i.split()) for i in ifaces))
 
     permits = get_permits(decl_node)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,6 +92,18 @@ class TestMethodMode:
         assert "fetchOfficesForBusinessUnitId" in stdout
         assert "fetchShiftsForBusinessUnitId" in stdout
 
+    def test_implicit_class_list_methods(self):
+        path = str(fixture_path("ImplicitClass.java"))
+        stdout, _, _ = run_jskim(path, "--list")
+        assert "implicit class ImplicitClass" in stdout
+        assert "main()" in stdout
+
+    def test_implicit_class_extract_method(self):
+        path = str(fixture_path("ImplicitClass.java"))
+        stdout, _, _ = run_jskim(path, "main")
+        assert "implicit class ImplicitClass" in stdout
+        assert "Hello from implicit class" in stdout
+
 
 class TestProjectMode:
     def test_directory_scan(self):

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,5 +1,7 @@
 """Tests for jskim.diff — git diff summarization."""
 
+import subprocess
+
 import pytest
 from jskim.diff import parse_diff_output, _changes_overlap, _resolve_base_ref, format_diff_output
 from pathlib import Path
@@ -409,3 +411,48 @@ class TestDiffIntegration:
         statuses = {f["status"] for f in files}
         assert "added" in statuses
         assert "deleted" in statuses
+
+
+class TestDiffOverloads:
+    def _format_repo_diff(self, tmp_path, old_source, new_source):
+        subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+        subprocess.run(["git", "config", "user.name", "Test User"], cwd=tmp_path, check=True)
+        subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True)
+
+        path = tmp_path / "Foo.java"
+        path.write_text(old_source, encoding="utf-8")
+        subprocess.run(["git", "add", "Foo.java"], cwd=tmp_path, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "initial"], cwd=tmp_path, check=True)
+
+        path.write_text(new_source, encoding="utf-8")
+        diff = subprocess.run(
+            ["git", "diff", "HEAD"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        changed = parse_diff_output(diff)
+        return format_diff_output(changed, tmp_path, "HEAD")
+
+    def test_added_overload_marked_new(self, tmp_path):
+        output = self._format_repo_diff(
+            tmp_path,
+            "class Foo {\n    void foo(int x) {}\n}\n",
+            "class Foo {\n    void foo(int x) {}\n    void foo(String x) {}\n}\n",
+        )
+        assert "[NEW]" in output
+        assert "void foo(String x)" in output
+        assert "[MODIFIED]" not in output
+
+    def test_replaced_overload_marked_new_and_deleted(self, tmp_path):
+        output = self._format_repo_diff(
+            tmp_path,
+            "class Foo {\n    void foo(int x) {}\n}\n",
+            "class Foo {\n    void foo(String x) {}\n}\n",
+        )
+        assert "[NEW]" in output
+        assert "[DELETED]" in output
+        assert "void foo(String x)" in output
+        assert "void foo(int x)" in output
+        assert "[MODIFIED]" not in output

--- a/tests/test_method.py
+++ b/tests/test_method.py
@@ -114,6 +114,14 @@ class TestParseMethods:
         assert "area" in names  # present in multiple classes
         assert "getColor" in names
 
+    def test_implicit_class_methods(self):
+        content = load_fixture("ImplicitClass.java")
+        parsed = parse_methods(content, source_name="ImplicitClass.java")
+        assert parsed["class_name"] == "ImplicitClass"
+        assert parsed["class_declaration"] == "implicit class ImplicitClass"
+        assert len(parsed["methods"]) == 1
+        assert parsed["methods"][0]["name"] == "main"
+
 
 # ---------------------------------------------------------------------------
 # list_methods
@@ -157,6 +165,13 @@ class TestListMethods:
         output = list_methods(parsed)
         assert "cabUpdateEventKafkaListenerContainerFactory" in output
         assert "cabCreationEventConsumerFactory" in output
+
+    def test_implicit_class_list_methods(self):
+        content = load_fixture("ImplicitClass.java")
+        parsed = parse_methods(content, source_name="ImplicitClass.java")
+        output = list_methods(parsed)
+        assert "implicit class ImplicitClass" in output
+        assert "main()" in output
 
 
 # ---------------------------------------------------------------------------
@@ -237,6 +252,13 @@ class TestExtractMethods:
         output = extract_methods(parsed, ["isSingleEscortTrip"])
         # The Javadoc above isSingleEscortTrip should be captured
         assert "single escort trip" in output.lower()
+
+    def test_implicit_class_extract(self):
+        content = load_fixture("ImplicitClass.java")
+        parsed = parse_methods(content, source_name="ImplicitClass.java")
+        output = extract_methods(parsed, ["main"])
+        assert "implicit class ImplicitClass" in output
+        assert "Hello from implicit class" in output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -186,6 +186,15 @@ class TestScanJavaFile:
         assert shape["class_type"] == "interface"
         assert shape["method_count"] == 2  # area, perimeter
 
+    def test_implicit_class_scanned(self):
+        path = fixture_path("ImplicitClass.java")
+        infos = scan_java_file(path)
+        assert len(infos) == 1
+        info = infos[0]
+        assert info["class_type"] == "implicit class"
+        assert info["class_name"] == "ImplicitClass"
+        assert info["method_count"] == 1
+
 
 # ---------------------------------------------------------------------------
 # find_dependencies
@@ -464,6 +473,29 @@ class TestFormatOutput:
         output = format_output(infos)
         assert "inner:" in output
 
+    def test_implicit_class_output(self):
+        path = fixture_path("ImplicitClass.java")
+        infos = scan_java_file(path)
+        output = format_output(infos)
+        assert "implicit class ImplicitClass" in output
+
+    def test_multi_type_file_totals_count_unique_files(self):
+        path = fixture_path("SealedAndMultiClass.java")
+        infos = scan_java_file(path)
+        output = format_output(infos)
+        assert "Project Map: 1 files, 70 lines" in output
+        assert "com.example.edgecases (1 files, 70 lines)" in output
+
+    def test_interface_extends_output(self, tmp_path):
+        path = tmp_path / "Child.java"
+        path.write_text(
+            "package demo;\npublic interface Child extends ParentA, ParentB {}\n",
+            encoding="utf-8",
+        )
+        infos = scan_java_file(path)
+        output = format_output(infos)
+        assert "interface Child extends ParentA, ParentB" in output
+
 
 # ---------------------------------------------------------------------------
 # Full project scan
@@ -495,3 +527,12 @@ class TestFullProjectScan:
         output = format_output(all_infos, show_endpoints=True)
         # No REST controllers in fixtures, so no endpoints section expected
         assert "Project Map:" in output
+
+    def test_scan_all_fixtures_totals_use_unique_files(self):
+        java_files = sorted(FIXTURES_DIR.rglob("*.java"))
+        all_infos = []
+        for f in java_files:
+            all_infos.extend(scan_java_file(f))
+
+        output = format_output(all_infos)
+        assert "Project Map: 34 files, 2003 lines" in output

--- a/tests/test_skim.py
+++ b/tests/test_skim.py
@@ -320,7 +320,9 @@ class TestParseJava:
     def test_implicitly_declared_class(self):
         content = 'void main() { System.out.println("Hello"); }'
         parsed = parse_java(content)
-        assert parsed["class_declaration"] is None
+        assert parsed["class_declaration"] == "implicit class"
+        assert len(parsed["methods"]) == 1
+        assert parsed["methods"][0]["sig"] == "void main()"
         assert parsed["total_lines"] == 1
 
     def test_generic_type_in_declaration(self):
@@ -505,9 +507,11 @@ class TestFormatOutput:
 
     def test_implicit_class_output(self):
         content = load_fixture("ImplicitClass.java")
-        parsed = parse_java(content)
+        parsed = parse_java(content, source_name="ImplicitClass.java")
         output = format_output(parsed, "ImplicitClass.java")
         assert output.startswith("//")
+        assert "implicit class ImplicitClass" in output
+        assert "void main()" in output
         assert "total:" in output
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -6,6 +6,7 @@ from jskim.util import (
     get_annotations,
     get_annotations_rich,
     build_method_signature,
+    build_method_identity,
     extract_import_path,
     parse_file_structure,
     find_first_type_declaration,
@@ -131,6 +132,13 @@ class TestParseFileStructure:
         result = parse_file_structure(source)
         assert len(result["type_nodes"]) == 1
         assert result["type_nodes"][0].type == "annotation_type_declaration"
+
+    def test_implicit_source_members(self):
+        source = b"void main() { System.out.println(\"Hello\"); }"
+        result = parse_file_structure(source)
+        assert result["type_nodes"] == []
+        assert len(result["program_members"]) == 1
+        assert result["program_members"][0].type == "method_declaration"
 
 
 # ---------------------------------------------------------------------------
@@ -286,6 +294,14 @@ class TestGetInterfaces:
         decl = find_first_type_declaration(root)
         ifaces = get_interfaces(decl)
         assert len(ifaces) == 2
+
+    def test_interface_extends_interfaces(self):
+        root = parse_java_bytes(b"interface Foo extends Bar, Baz {}")
+        decl = find_first_type_declaration(root)
+        ifaces = get_interfaces(decl)
+        assert len(ifaces) == 2
+        assert "Bar" in ifaces
+        assert "Baz" in ifaces
 
 
 # ---------------------------------------------------------------------------
@@ -523,6 +539,35 @@ class TestBuildMethodSignature:
         assert "bar()" in sig
 
 
+class TestBuildMethodIdentity:
+    def _get_first_method(self, source):
+        root = parse_java_bytes(source)
+        decl = find_first_type_declaration(root)
+        body = get_class_body(decl)
+        for member in get_body_members(body):
+            if member.type in METHOD_NODES:
+                return member
+        return None
+
+    def test_method_uses_parameter_types(self):
+        method = self._get_first_method(
+            b"class Foo { void bar(int count, @A final String name) {} }"
+        )
+        assert build_method_identity(method) == "bar(int, String)"
+
+    def test_constructor_identity(self):
+        method = self._get_first_method(b"class Foo { Foo(int count) {} }")
+        assert build_method_identity(method) == "Foo(int)"
+
+    def test_compact_constructor_identity(self):
+        method = self._get_first_method(b"record Foo(int count) { Foo {} }")
+        assert build_method_identity(method) == "Foo()"
+
+    def test_annotation_element_identity(self):
+        method = self._get_first_method(b"@interface Foo { String value(); }")
+        assert build_method_identity(method) == "value()"
+
+
 # ---------------------------------------------------------------------------
 # build_class_declaration_text
 # ---------------------------------------------------------------------------
@@ -545,6 +590,12 @@ class TestBuildClassDeclarationText:
         decl = find_first_type_declaration(root)
         text = build_class_declaration_text(decl)
         assert "implements Serializable" in text
+
+    def test_interface_with_extends(self):
+        root = parse_java_bytes(b"public interface Foo extends Serializable, AutoCloseable {}")
+        decl = find_first_type_declaration(root)
+        text = build_class_declaration_text(decl)
+        assert "extends Serializable, AutoCloseable" in text
 
     def test_sealed_class_with_permits(self):
         source = b"public sealed class Shape permits Circle, Rectangle {}"


### PR DESCRIPTION

This PR addresses the review findings across skim, project, and diff mode, and adds regression coverage for each fix.

## Changes

- add support for Java simple source files without an explicit top-level type
- treat those files as `implicit class <FileStem>` in skim, method, and project output
- fix project map totals so file counts and line counts are based on unique files, not top-level type declarations
- fix interface inheritance parsing so `extends_interfaces` is preserved in summaries and project output
- make diff mode overload-aware by matching methods using name plus parameter types instead of bare method name
- show deleted overloads with their previous signature in diff output
- update `README.md` and `SKILL.md` to reflect the new behavior

## Why

Before this change:
- simple source files like `ImplicitClass.java` were silently dropped in skim and method mode
- project totals overcounted files and lines when a file contained multiple top-level types
- interface `extends` clauses were omitted from rendered declarations
- diff mode misclassified overloaded method additions/removals as generic modifications